### PR TITLE
Updated tests and fixed regressions

### DIFF
--- a/lib/CryptoNoteCore/Blockchain.cpp
+++ b/lib/CryptoNoteCore/Blockchain.cpp
@@ -1765,15 +1765,13 @@ bool Blockchain::checkTransactionInputs(const Transaction& tx, const Crypto::Has
 
 bool Blockchain::is_tx_spendtime_unlocked(uint64_t unlock_time) {
   if (unlock_time < m_currency.maxBlockHeight()) {
-    //interpret as block index
+    // interpret as block index
     if (getCurrentBlockchainHeight() - 1 + m_currency.lockedTxAllowedDeltaBlocks() >= unlock_time)
       return true;
     else
       return false;
   } else {
-    //interpret as time
-
-     // compare with last block timestamp + delta seconds
+    // interpret as time, compare with last block timestamp + delta seconds
     const uint64_t lastBlockTimestamp = getBlockTimestamp(getCurrentBlockchainHeight() - 1);
     if (lastBlockTimestamp + m_currency.lockedTxAllowedDeltaSeconds() >= unlock_time)
       return true;

--- a/lib/P2p/PeerListManager.cpp
+++ b/lib/P2p/PeerListManager.cpp
@@ -16,12 +16,11 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Qwertycoin.  If not, see <http://www.gnu.org/licenses/>.
 
-
 #include <time.h>
 #include <boost/foreach.hpp>
 #include <P2p/PeerListManager.h>
-#include <System/Ipv4Address.h>
 #include <Serialization/SerializationOverloads.h>
+#include <System/Ipv4Address.h>
 
 using namespace CryptoNote;
 
@@ -158,7 +157,7 @@ bool PeerlistManager::is_ip_allowed(uint32_t ip) const
         return false;
     }
 
-    return (m_allow_local_ip && addr.isPrivate());
+    return !(!m_allow_local_ip && addr.isPrivate());
 }
 
 bool PeerlistManager::get_peerlist_head(std::list<PeerlistEntry> &bs_head, uint32_t depth) const

--- a/lib/P2p/PeerListManager.h
+++ b/lib/P2p/PeerListManager.h
@@ -71,14 +71,14 @@ public:
     bool merge_peerlist(const std::list<PeerlistEntry> &outer_bs);
     bool get_peerlist_head(std::list<PeerlistEntry> &bs_head,
                            uint32_t depth = CryptoNote::P2P_DEFAULT_PEERS_IN_HANDSHAKE) const;
-    bool get_peerlist_full(std::list<PeerlistEntry> &pl_gray, std::list<PeerlistEntry> &pl_white) const;
+    bool get_peerlist_full(std::list<PeerlistEntry> &pl_gray,
+                           std::list<PeerlistEntry> &pl_white) const;
     bool get_white_peer_by_index(PeerlistEntry &p, size_t i) const;
     bool get_gray_peer_by_index(PeerlistEntry &p, size_t i) const;
     bool append_with_peer_white(const PeerlistEntry &pr);
     bool append_with_peer_gray(const PeerlistEntry &pr);
     bool set_peer_just_seen(PeerIdType peer, uint32_t ip, uint32_t port);
     bool set_peer_just_seen(PeerIdType peer, const NetworkAddress &addr);
-    bool set_peer_unreachable(const PeerlistEntry &pr);
     bool is_ip_allowed(uint32_t ip) const;
     void trim_white_peerlist();
     void trim_gray_peerlist();

--- a/tests/CoreTests/TransactionValidation.cpp
+++ b/tests/CoreTests/TransactionValidation.cpp
@@ -538,8 +538,8 @@ bool gen_tx_check_input_unlock_time::generate(std::vector<test_event_entry>& eve
   make_tx_to_acc(1, blk_3_height - 1);
   make_tx_to_acc(2, blk_3_height);
   make_tx_to_acc(3, blk_3_height + 1);
-  make_tx_to_acc(4, time(0) - 1);
-  make_tx_to_acc(5, time(0) + 60 * 60);
+  make_tx_to_acc(4, blk_1r.timestamp - 1);
+  make_tx_to_acc(5, blk_1r.timestamp + 60 * 60);
   MAKE_NEXT_BLOCK_TX_LIST(events, blk_2, blk_1r, miner_account, txs_0);
 
   std::list<Transaction> txs_1;


### PR DESCRIPTION
1. Changes in PR #75 broke test `CoreTests.TransactionValidation.gen_tx_check_input_unlock_time`, test data was updated to match new logic;
2. Fixed regressions in `lib/P2p` that broke test `UnitTests.peer_list.peer_list_general`.