### PR TITLE
Add p2p version blocking (optional startup flag)

### DIFF
--- a/lib/P2p/NetNode.cpp
+++ b/lib/P2p/NetNode.cpp
@@ -163,7 +163,7 @@ const command_line::arg_descriptor<bool> arg_p2p_hide_my_port = {
 };
 const command_line::arg_descriptor<std::string> arg_p2p_exclusive_version = {
     "exclusive-version",
-    "Refuse connections from nodes that are not running the specified version. (specify version 5.1.4.3031, etc...)"
+    "Refuse connections from nodes that are not running the specified version. (specify version in short format, i.e. 5.1.4)"
 };
 
 std::string print_peerlist_to_string(const std::list<PeerlistEntry> &pl)

--- a/lib/P2p/NetNode.cpp
+++ b/lib/P2p/NetNode.cpp
@@ -161,6 +161,10 @@ const command_line::arg_descriptor<bool> arg_p2p_hide_my_port = {
     false,
     true
 };
+const command_line::arg_descriptor<std::string> arg_p2p_exclusive_version = {
+    "exclusive-version",
+    "Refuse connections from nodes that are not running the specified version. (specify version 5.1.4.3031, etc...)"
+};
 
 std::string print_peerlist_to_string(const std::list<PeerlistEntry> &pl)
 {
@@ -357,6 +361,7 @@ void NodeServer::init_options(boost::program_options::options_description &desc)
     command_line::add_arg(desc, arg_p2p_add_exclusive_node);
     command_line::add_arg(desc, arg_p2p_seed_node);
     command_line::add_arg(desc, arg_p2p_hide_my_port);
+    command_line::add_arg(desc, arg_p2p_exclusive_version);
 }
 
 bool NodeServer::init_config()
@@ -515,6 +520,7 @@ bool NodeServer::handle_command_line(const boost::program_options::variables_map
     m_port = command_line::get_arg(vm, arg_p2p_bind_port);
     m_external_port = command_line::get_arg(vm, arg_p2p_external_port);
     m_allow_local_ip = command_line::get_arg(vm, arg_p2p_allow_local_ip);
+    m_node_version = command_line::get_arg(vm, arg_p2p_exclusive_version);
 
     if (command_line::has_arg(vm, arg_p2p_add_peer)) {
         std::vector<std::string> perrs = command_line::get_arg(vm, arg_p2p_add_peer);
@@ -559,6 +565,7 @@ bool NodeServer::handleConfig(const NetNodeConfig &config)
     m_port = std::to_string(config.getBindPort());
     m_external_port = config.getExternalPort();
     m_allow_local_ip = config.getAllowLocalIp();
+    m_node_version = config.getExclusiveVersion();
 
     auto peers = config.getPeers();
     std::copy(peers.begin(), peers.end(), std::back_inserter(m_command_line_peers));
@@ -633,6 +640,9 @@ bool NodeServer::init(const NetNodeConfig &config)
     for(auto &p : m_command_line_peers) {
         m_peerlist.append_with_peer_white(p);
     }
+
+    if (!m_node_version.empty())
+      logger(INFO, BRIGHT_GREEN) << "[VERSION BLOCKING] Daemon Version: " << m_node_version << " - blocking daemons that do not reply with this specified version.";
 
     // only in case if we really sure that we have external visible ip
     m_have_address = true;
@@ -765,6 +775,14 @@ bool NodeServer::handshake(CryptoNote::LevinProtocol &proto,
             << "), closing connection.";
         return false;
     }
+
+  if(!m_node_version.empty()) {
+    if (rsp.node_data.node_version != m_node_version) {
+      logger(Logging::ERROR) << context << "COMMAND_HANDSHAKE: invoked, but peer is not running the exclusive version specified, dropping connection!";
+      return false;
+    }
+  }
+
 
     if (!handle_remote_peerlist(rsp.local_peerlist, rsp.node_data.local_time, context)) {
         add_host_fail(context.m_remote_ip);
@@ -1224,6 +1242,7 @@ bool NodeServer::get_local_node_data(basic_node_data &node_data)
     } else {
         node_data.my_port = 0;
     }
+    node_data.node_version = m_node_version;
     node_data.network_id = m_network_id;
     return true;
 }

--- a/lib/P2p/NetNode.h
+++ b/lib/P2p/NetNode.h
@@ -42,6 +42,7 @@
 #include <System/Timer.h>
 #include <System/TcpConnection.h>
 #include <System/TcpListener.h>
+#include "version.h"
 
 namespace System {
 
@@ -303,6 +304,7 @@ private:
     bool m_allow_local_ip;
     bool m_hide_my_port;
     std::string m_p2p_state_filename;
+    std::string m_node_version;
 
     System::Dispatcher &m_dispatcher;
     System::ContextGroup m_workingContextGroup;

--- a/lib/P2p/NetNodeConfig.cpp
+++ b/lib/P2p/NetNodeConfig.cpp
@@ -70,6 +70,10 @@ const command_line::arg_descriptor<bool> arg_p2p_hide_my_port = {
     false,
     true
 };
+const command_line::arg_descriptor<std::string> arg_p2p_exclusive_version = {
+    "exclusive-version",
+    "Refuse connections from nodes not running the specified version (specify version as 5.1.4.3031, etc...)"
+};
 
 bool parsePeerFromString(NetworkAddress &pe, const std::string &node_addr)
 {
@@ -105,6 +109,7 @@ NetNodeConfig::NetNodeConfig()
     hideMyPort = false;
     configFolder = Tools::getDefaultDataDirectory();
     testnet = false;
+    exclusiveVersion = "";
 }
 
 void NetNodeConfig::initOptions(boost::program_options::options_description &desc)
@@ -118,6 +123,7 @@ void NetNodeConfig::initOptions(boost::program_options::options_description &des
     command_line::add_arg(desc, arg_p2p_add_exclusive_node);
     command_line::add_arg(desc, arg_p2p_seed_node);
     command_line::add_arg(desc, arg_p2p_hide_my_port);
+    command_line::add_arg(desc, arg_p2p_exclusive_version);
 }
 
 bool NetNodeConfig::init(const boost::program_options::variables_map &vm)
@@ -147,6 +153,10 @@ bool NetNodeConfig::init(const boost::program_options::variables_map &vm)
             || configFolder == Tools::getDefaultDataDirectory())) {
         configFolder = command_line::get_arg(vm, command_line::arg_data_dir);
     }
+
+  if (vm.count(arg_p2p_exclusive_version.name) != 0 && (!vm[arg_p2p_exclusive_version.name].defaulted() || exclusiveVersion.empty())) {
+    exclusiveVersion = command_line::get_arg(vm, arg_p2p_exclusive_version);
+  }
 
     p2pStateFilename = CryptoNote::parameters::P2P_NET_DATA_FILENAME;
 
@@ -257,6 +267,10 @@ std::string NetNodeConfig::getConfigFolder() const
     return configFolder;
 }
 
+std::string NetNodeConfig::getExclusiveVersion() const {
+  return exclusiveVersion;
+}
+
 void NetNodeConfig::setP2pStateFilename(const std::string &filename)
 {
     p2pStateFilename = filename;
@@ -310,6 +324,10 @@ void NetNodeConfig::setHideMyPort(bool hide)
 void NetNodeConfig::setConfigFolder(const std::string &folder)
 {
     configFolder = folder;
+}
+
+void NetNodeConfig::setExclusiveVersion(std::string& nodeVersion) {
+  exclusiveVersion = nodeVersion;
 }
 
 } // namespace CryptoNote

--- a/lib/P2p/NetNodeConfig.cpp
+++ b/lib/P2p/NetNodeConfig.cpp
@@ -72,7 +72,7 @@ const command_line::arg_descriptor<bool> arg_p2p_hide_my_port = {
 };
 const command_line::arg_descriptor<std::string> arg_p2p_exclusive_version = {
     "exclusive-version",
-    "Refuse connections from nodes not running the specified version (specify version as 5.1.4.3031, etc...)"
+    "Refuse connections from nodes not running the specified version (specify version in short format, i.e. 5.1.4)"
 };
 
 bool parsePeerFromString(NetworkAddress &pe, const std::string &node_addr)

--- a/lib/P2p/NetNodeConfig.h
+++ b/lib/P2p/NetNodeConfig.h
@@ -46,6 +46,7 @@ public:
     std::vector<NetworkAddress> getSeedNodes() const;
     bool getHideMyPort() const;
     std::string getConfigFolder() const;
+    std::string getExclusiveVersion() const;
 
     void setP2pStateFilename(const std::string &filename);
     void setTestnet(bool isTestnet);
@@ -59,6 +60,8 @@ public:
     void setSeedNodes(const std::vector<NetworkAddress> &addresses);
     void setHideMyPort(bool hide);
     void setConfigFolder(const std::string &folder);
+    void setExclusiveVersion(std::string& nodeVersion);
+    std::string exclusiveVersion;
 
 private:
     std::string bindIp;

--- a/lib/P2p/P2pNode.cpp
+++ b/lib/P2p/P2pNode.cpp
@@ -507,6 +507,7 @@ basic_node_data P2pNode::getNodeData() const
     nodeData.version = P2PProtocolVersion::CURRENT;
     nodeData.local_time = time(nullptr);
     nodeData.peer_id = m_myPeerId;
+    nodeData.node_version = PROJECT_VERSION;
 
     if (m_cfg.getHideMyPort()) {
         nodeData.my_port = 0;

--- a/lib/P2p/P2pProtocolDefinitions.h
+++ b/lib/P2p/P2pProtocolDefinitions.h
@@ -25,6 +25,7 @@
 #include <P2p/P2pProtocolTypes.h>
 #include <Serialization/ISerializer.h>
 #include <Serialization/SerializationOverloads.h>
+#include "version.h"
 
 namespace CryptoNote {
 
@@ -71,6 +72,7 @@ struct basic_node_data
         KV_MEMBER(peer_id)
         KV_MEMBER(local_time)
         KV_MEMBER(my_port)
+        KV_MEMBER(node_version)
     }
 
     uuid network_id;
@@ -78,6 +80,7 @@ struct basic_node_data
     uint64_t local_time;
     uint32_t my_port;
     PeerIdType peer_id;
+    std::string node_version = PROJECT_VERSION;
 };
 
 struct CORE_SYNC_DATA

--- a/lib/P2p/PeerListManager.h
+++ b/lib/P2p/PeerListManager.h
@@ -90,6 +90,7 @@ public:
 
 private:
     std::string m_config_folder;
+    const std::string m_node_version;
     bool m_allow_local_ip;
     peers_indexed m_peers_gray;
     peers_indexed m_peers_white;


### PR DESCRIPTION
When starting the daemon, this feature allows the user to specify an exclusive version number with the `--exclusive-version 5.1.4` startup flag, for example.  

When using the startup flag with a specific version (short format, no build version), the node that the user is running will drop connections to any daemon that attempts a handshake, but does not reply with the specified version.  Replies from other p2p nodes are generated with the `PROJECT_VERSION/m_node_version` (this was apparently already encoded in peer comms, just not exposed)

By adding this version to p2p communications for our node, we can get an authentic response from other nodes (not spoof-resistant, though).  This can be easily expanded to use the long version with a specific commit number.

Note that this startup flag affects *only the node using the flag*.  This is not a censorship functionality, but rather a connection filtering one that affects only the user running the node.  Kind of like a firewall.

Example: 
![Screenshot from 2019-05-27 01-29-47](https://user-images.githubusercontent.com/37732338/58397437-f50aa300-801e-11e9-9bcb-82e4226bf7ea.png)
