### PR TITLE
Add Update height for new EPoSE Reward Scheme

### DIFF
--- a/lib/CryptoNoteCore/Currency.cpp
+++ b/lib/CryptoNoteCore/Currency.cpp
@@ -178,7 +178,12 @@ bool Currency::getBlockReward(
     }
 
     emissionChange = penalizedBaseReward - (fee - penalizedFee);
-    reward = (penalizedBaseReward + penalizedFee) * consistency;
+
+    if (height < CryptoNote::parameters::UPGRADE_HEIGHT_REWARD_SCHEME) {
+        reward = penalizedBaseReward + penalizedFee;
+    } else {
+        reward = (penalizedBaseReward + penalizedFee) * consistency;
+    }
 
     return true;
 }

--- a/src/config/CryptoNoteConfig.h
+++ b/src/config/CryptoNoteConfig.h
@@ -138,6 +138,8 @@ const uint32_t UPGRADE_HEIGHT_V4                              = 110520;
 const uint32_t UPGRADE_HEIGHT_V5                              = 250720;
 const uint32_t UPGRADE_HEIGHT_V6                              = 4294967295;
 
+const uint32_t UPGRADE_HEIGHT_REWARD_SCHEME                   = 400000;
+
 const unsigned UPGRADE_VOTING_THRESHOLD                      = 90; // percent
 const uint32_t UPGRADE_VOTING_WINDOW                         = EXPECTED_NUMBER_OF_BLOCKS_PER_DAY;  // blocks
 const uint32_t UPGRADE_WINDOW                                = EXPECTED_NUMBER_OF_BLOCKS_PER_DAY;  // blocks


### PR DESCRIPTION
Activate new EPoSE Reward Scheme #1 on Height 400,000

More Informations here: https://github.com/qwertycoin-org/qwertycoin/issues/78