### PR TITLE
Add better P2P version check handle...

### DIFF
--- a/lib/CryptoNoteProtocol/CryptoNoteProtocolHandler.cpp
+++ b/lib/CryptoNoteProtocol/CryptoNoteProtocolHandler.cpp
@@ -819,7 +819,7 @@ void CryptoNoteProtocolHandler::relay_transactions(NOTIFY_NEW_TRANSACTIONS::requ
 void CryptoNoteProtocolHandler::requestMissingPoolTransactions(
     const CryptoNoteConnectionContext &context)
 {
-    if (context.version < P2PProtocolVersion::V1) {
+    if (context.version < 1) {
         return;
     }
 

--- a/lib/P2p/NetNode.cpp
+++ b/lib/P2p/NetNode.cpp
@@ -759,7 +759,7 @@ bool NodeServer::handshake(CryptoNote::LevinProtocol &proto,
     m_payload_handler.get_payload_sync_data(arg.payload_data);
 
     if (!proto.invoke(COMMAND_HANDSHAKE::ID, arg, rsp)) {
-        logger(Logging::ERROR,BRIGHT_RED)
+        logger(Logging::ERROR)
             << context
             << "Failed to invoke COMMAND_HANDSHAKE, closing connection.";
         return false;
@@ -768,7 +768,7 @@ bool NodeServer::handshake(CryptoNote::LevinProtocol &proto,
     context.version = rsp.node_data.version;
 
     if (rsp.node_data.network_id != m_network_id) {
-        logger(Logging::ERROR,BRIGHT_RED)
+        logger(Logging::ERROR)
             << context
             << "COMMAND_HANDSHAKE Failed, wrong network!  ("
             << rsp.node_data.network_id
@@ -802,7 +802,7 @@ bool NodeServer::handshake(CryptoNote::LevinProtocol &proto,
 
     if (!handle_remote_peerlist(rsp.local_peerlist, rsp.node_data.local_time, context)) {
         add_host_fail(context.m_remote_ip);
-        logger(Logging::ERROR,BRIGHT_RED)
+        logger(Logging::ERROR)
             << context
             << "COMMAND_HANDSHAKE: failed to handle_remote_peerlist(...), closing connection.";
         return false;
@@ -1482,7 +1482,11 @@ int NodeServer::handle_handshake(int command,
     context.version = arg.node_data.version;
 
 	if (!is_remote_host_allowed(context.m_remote_ip)) {
-        logger(Logging::DEBUGGING) << context << "Banned node connected " << Common::ipAddressToString(context.m_remote_ip) << ", dropping connection.";
+        logger(Logging::DEBUGGING)
+            << context
+            << "Banned node connected "
+            << Common::ipAddressToString(context.m_remote_ip)
+            << ", dropping connection.";
         context.m_state = CryptoNoteConnectionContext::state_shutdown;
         return 1;
 	}

--- a/lib/P2p/P2pNode.cpp
+++ b/lib/P2p/P2pNode.cpp
@@ -447,11 +447,25 @@ bool P2pNode::fetchPeerList(ContextPtr connection)
         }
 
         if (response.node_data.network_id != request.node_data.network_id) {
-            logger(ERROR)
+            logger(ERROR,BRIGHT_RED)
                 << *connection
                 << "COMMAND_HANDSHAKE failed, wrong network: "
                 << response.node_data.network_id;
             return false;
+        }
+
+        if (response.node_data.version < CryptoNote::P2P_MINIMUM_VERSION) {
+            logger(ERROR,BRIGHT_RED)
+                << *connection
+                << "COMMAND_HANDSHAKE Failed, peer is wrong version: "
+                << std::to_string(response.node_data.version);
+            return false;
+        } else if ((response.node_data.version - CryptoNote::P2P_CURRENT_VERSION) >= CryptoNote::P2P_UPGRADE_WINDOW) {
+            logger(WARNING)
+                << *connection
+                << "COMMAND_HANDSHAKE Warning, your software may be out of date. Please visit: "
+                << CryptoNote::LATEST_VERSION_URL
+                << " for the latest version.";
         }
 
         return handleRemotePeerList(response.local_peerlist, response.node_data.local_time);
@@ -504,7 +518,7 @@ basic_node_data P2pNode::getNodeData() const
 {
     basic_node_data nodeData;
     nodeData.network_id = m_cfg.getNetworkId();
-    nodeData.version = P2PProtocolVersion::CURRENT;
+    nodeData.version = CryptoNote::P2P_CURRENT_VERSION;
     nodeData.local_time = time(nullptr);
     nodeData.peer_id = m_myPeerId;
     nodeData.node_version = PROJECT_VERSION;
@@ -610,6 +624,15 @@ void P2pNode::handleNodeData(const basic_node_data &node, P2pContext &context)
     if (node.network_id != m_cfg.getNetworkId()) {
         std::ostringstream msg;
         msg << context << "COMMAND_HANDSHAKE Failed, wrong network!  (" << node.network_id << ")";
+        throw std::runtime_error(msg.str());
+    }
+
+    if (node.version < CryptoNote::P2P_MINIMUM_VERSION) {
+        std::ostringstream msg;
+        msg << context
+            << "COMMAND_HANDSHAKE Failed, peer is wrong version! ("
+            << std::to_string(node.version)
+            << ")";
         throw std::runtime_error(msg.str());
     }
 

--- a/lib/P2p/P2pNode.cpp
+++ b/lib/P2p/P2pNode.cpp
@@ -447,7 +447,7 @@ bool P2pNode::fetchPeerList(ContextPtr connection)
         }
 
         if (response.node_data.network_id != request.node_data.network_id) {
-            logger(ERROR,BRIGHT_RED)
+            logger(ERROR)
                 << *connection
                 << "COMMAND_HANDSHAKE failed, wrong network: "
                 << response.node_data.network_id;
@@ -455,7 +455,7 @@ bool P2pNode::fetchPeerList(ContextPtr connection)
         }
 
         if (response.node_data.version < CryptoNote::P2P_MINIMUM_VERSION) {
-            logger(ERROR,BRIGHT_RED)
+            logger(ERROR)
                 << *connection
                 << "COMMAND_HANDSHAKE Failed, peer is wrong version: "
                 << std::to_string(response.node_data.version);

--- a/lib/P2p/P2pProtocolDefinitions.h
+++ b/lib/P2p/P2pProtocolDefinitions.h
@@ -53,13 +53,6 @@ struct network_config
     uint32_t send_peerlist_sz;
 };
 
-enum P2PProtocolVersion : uint8_t
-{
-    V0 = 0,
-    V1 = 1,
-    CURRENT = V1
-};
-
 struct basic_node_data
 {
     void serialize(ISerializer &s)

--- a/src/config/CryptoNoteConfig.h
+++ b/src/config/CryptoNoteConfig.h
@@ -186,11 +186,11 @@ const size_t   P2P_LOCAL_GRAY_PEERLIST_LIMIT                 =  5000;
 // P2P Network Configuration Section - This defines our current P2P network version
 // and the minimum version for communication between nodes
 const uint8_t  P2P_CURRENT_VERSION                           = 5;
-const uint8_t  P2P_MINIMUM_VERSION                           = 4;
+const uint8_t  P2P_MINIMUM_VERSION                           = 1;
 
 // This defines the number of versions ahead we must see peers before we start displaying
 // warning messages that we need to upgrade our software.
-const uint8_t  P2P_UPGRADE_WINDOW                            = 2;
+const uint8_t  P2P_UPGRADE_WINDOW                            = 1;
 
 const size_t   P2P_CONNECTION_MAX_WRITE_BUFFER_SIZE          = 64 * 1024 * 1024; // 64 MB
 const uint32_t P2P_DEFAULT_CONNECTIONS_COUNT                 = 8;


### PR DESCRIPTION
Implementation of advanced secured P2P Handshake Connection based on minimum peer versions. Build on top of @who-biz previous PR (https://github.com/qwertycoin-org/qwertycoin/pull/87).

With the idea of Turtlecoin I want to reject nodes that do not run in the minimum version, or nodes that are at least 1 version steps above or below the current version.

I think we need 2 Versions to release the full system because i've set the minimum version to 1 to avoid banning previous nodes (5.1.3 and higher). In the version after next we have to increment the current version and set the minimum version to 5. With this release all new nodes wil receive version 5 as current version and accepted minimum version 1. In the release after next we will set current version to 6 and minimum accepted version to 5.

Any suggestions?

![Image of Ascii](https://cdn.qwertycoin.org/images/other/github/trash/photo5429257228638071747.jpg)