### PR TITLE
cryptonote_protocol_handler: prevent potential DoS

### DIFF
--- a/lib/CryptoNoteProtocol/CryptoNoteProtocolHandler.cpp
+++ b/lib/CryptoNoteProtocol/CryptoNoteProtocolHandler.cpp
@@ -411,6 +411,28 @@ int CryptoNoteProtocolHandler::handle_request_get_objects(
     CryptoNoteConnectionContext &context)
 {
     logger(Logging::TRACE) << context << "NOTIFY_REQUEST_GET_OBJECTS";
+
+    /* Essentially, one can send such a large amount of IDs that core exhausts
+    * all free memory. This issue can theoretically be exploited using very
+    * large CN blockchains, such as Monero.
+    *
+    * This is a partial fix. Thanks and credit given to CryptoNote author
+    * 'cryptozoidberg' for collaboration and the fix. Also thanks to
+    * 'moneromooo'. Referencing HackerOne report #506595.
+    *
+    * Thanks to aivve (Karbo)
+    */
+    if (arg.blocks.size() + arg.txs.size() > CURRENCY_PROTOCOL_MAX_OBJECT_REQUEST_COUNT)
+    {
+        logger(Logging::ERROR)
+            << context
+            << "Requested objects count is too big ("
+            << arg.blocks.size() << ") expected not more then "
+            << CURRENCY_PROTOCOL_MAX_OBJECT_REQUEST_COUNT;
+        m_p2p->drop_connection(context, true);
+        return 1;
+    }
+
     NOTIFY_RESPONSE_GET_OBJECTS::request rsp;
     if (!m_core.handle_get_objects(arg, rsp)) {
         logger(Logging::ERROR)

--- a/lib/CryptoNoteProtocol/CryptoNoteProtocolHandler.h
+++ b/lib/CryptoNoteProtocol/CryptoNoteProtocolHandler.h
@@ -30,6 +30,8 @@
 #include <P2p/NetNodeCommon.h>
 #include <P2p/ConnectionContext.h>
 
+#define CURRENCY_PROTOCOL_MAX_OBJECT_REQUEST_COUNT 500
+
 namespace System {
 
 class Dispatcher;


### PR DESCRIPTION
Essentially, one can send such a large amount of IDs that core exhausts all free memory. This issue can theoretically be exploited using very large CN blockchains, such as Monero.

This is a partial fix. Thanks and credit given to CryptoNote author 'cryptozoidberg' for collaboration and the fix. Also thanks to  'moneromooo'. Referencing HackerOne report https://hackerone.com/reports/506595

Thanks to aivve Karbo.