### PR TITLE
Fix qwertycoind crash

### DIFF
--- a/lib/CryptoNoteCore/Currency.cpp
+++ b/lib/CryptoNoteCore/Currency.cpp
@@ -140,7 +140,7 @@ bool Currency::getBlockReward(
     uint32_t height,
     uint64_t blockTarget) const
 {
-    assert(alreadyGeneratedCoins <= m_moneySupply);
+    //assert(alreadyGeneratedCoins <= m_moneySupply);
     assert(m_emissionSpeedFactor > 0 && m_emissionSpeedFactor <= 8 * sizeof(uint64_t));
 
     // Tail emission


### PR DESCRIPTION
This PR is a possible solution to issue #112.
Removed money supply assert from `Currency::getBlockReward(...)` method.