### PR TITLE
Updated Hunter (package manager)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,8 @@ set(HUNTER_CONFIGURATION_TYPES Release;Debug CACHE STRING "Hunter configuration 
 set(HUNTER_JOBS_NUMBER 4 CACHE STRING "Hunter jobs number")
 include(hunter/HunterGate)
 HunterGate(
-    URL "https://github.com/ruslo/hunter/archive/v0.23.190.tar.gz"
-    SHA1 "bc7da329d2493201de28f0c2a5fcd4de1415c477"
+    URL "https://github.com/cpp-pm/hunter/archive/v0.23.232.tar.gz"
+    SHA1 "413fcd1a89b7b484e89e9ab6bf7996550335a7e8"
     FILEPATH "${CMAKE_CURRENT_LIST_DIR}/cmake/hunter/HunterConfig.cmake"
 )
 

--- a/cmake/hunter/HunterGate.cmake
+++ b/cmake/hunter/HunterGate.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2013-2018, Ruslan Baratov
+# Copyright (c) 2013-2019, Ruslan Baratov
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -60,7 +60,7 @@ option(HUNTER_STATUS_PRINT "Print working status" ON)
 option(HUNTER_STATUS_DEBUG "Print a lot info" OFF)
 option(HUNTER_TLS_VERIFY "Enable/disable TLS certificate checking on downloads" ON)
 
-set(HUNTER_WIKI "https://github.com/ruslo/hunter/wiki")
+set(HUNTER_ERROR_PAGE "https://docs.hunter.sh/en/latest/reference/errors")
 
 function(hunter_gate_status_print)
   if(HUNTER_STATUS_PRINT OR HUNTER_STATUS_DEBUG)
@@ -79,9 +79,9 @@ function(hunter_gate_status_debug)
   endif()
 endfunction()
 
-function(hunter_gate_wiki wiki_page)
-  message("------------------------------ WIKI -------------------------------")
-  message("    ${HUNTER_WIKI}/${wiki_page}")
+function(hunter_gate_error_page error_page)
+  message("------------------------------ ERROR ------------------------------")
+  message("    ${HUNTER_ERROR_PAGE}/${error_page}.html")
   message("-------------------------------------------------------------------")
   message("")
   message(FATAL_ERROR "")
@@ -94,14 +94,13 @@ function(hunter_gate_internal_error)
   endforeach()
   message("[hunter ** INTERNAL **] [Directory:${CMAKE_CURRENT_LIST_DIR}]")
   message("")
-  hunter_gate_wiki("error.internal")
+  hunter_gate_error_page("error.internal")
 endfunction()
 
 function(hunter_gate_fatal_error)
-  cmake_parse_arguments(hunter "" "WIKI" "" "${ARGV}")
-  string(COMPARE EQUAL "${hunter_WIKI}" "" have_no_wiki)
-  if(have_no_wiki)
-    hunter_gate_internal_error("Expected wiki")
+  cmake_parse_arguments(hunter "" "ERROR_PAGE" "" "${ARGV}")
+  if("${hunter_ERROR_PAGE}" STREQUAL "")
+    hunter_gate_internal_error("Expected ERROR_PAGE")
   endif()
   message("")
   foreach(x ${hunter_UNPARSED_ARGUMENTS})
@@ -109,11 +108,11 @@ function(hunter_gate_fatal_error)
   endforeach()
   message("[hunter ** FATAL ERROR **] [Directory:${CMAKE_CURRENT_LIST_DIR}]")
   message("")
-  hunter_gate_wiki("${hunter_WIKI}")
+  hunter_gate_error_page("${hunter_ERROR_PAGE}")
 endfunction()
 
 function(hunter_gate_user_error)
-  hunter_gate_fatal_error(${ARGV} WIKI "error.incorrect.input.data")
+  hunter_gate_fatal_error(${ARGV} ERROR_PAGE "error.incorrect.input.data")
 endfunction()
 
 function(hunter_gate_self root version sha1 result)
@@ -195,7 +194,7 @@ function(hunter_gate_detect_root)
 
   hunter_gate_fatal_error(
       "Can't detect HUNTER_ROOT"
-      WIKI "error.detect.hunter.root"
+      ERROR_PAGE "error.detect.hunter.root"
   )
 endfunction()
 
@@ -214,7 +213,7 @@ function(hunter_gate_download dir)
         "Settings:"
         "  HUNTER_ROOT: ${HUNTER_GATE_ROOT}"
         "  HUNTER_SHA1: ${HUNTER_GATE_SHA1}"
-        WIKI "error.run.install"
+        ERROR_PAGE "error.run.install"
     )
   endif()
   string(COMPARE EQUAL "${dir}" "" is_bad)
@@ -400,7 +399,7 @@ macro(HunterGate)
       hunter_gate_fatal_error(
           "Please set HunterGate *before* 'project' command. "
           "Detected project: ${PROJECT_NAME}"
-          WIKI "error.huntergate.before.project"
+          ERROR_PAGE "error.huntergate.before.project"
       )
     endif()
 
@@ -470,7 +469,7 @@ macro(HunterGate)
             "HUNTER_ROOT (${HUNTER_GATE_ROOT}) contains spaces."
             "Set HUNTER_ALLOW_SPACES_IN_PATH=ON to skip this error"
             "(Use at your own risk!)"
-            WIKI "error.spaces.in.hunter.root"
+            ERROR_PAGE "error.spaces.in.hunter.root"
         )
       endif()
     endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -265,7 +265,7 @@ set(QwertycoinTests_SystemTests_SOURCES
 
 set(QwertycoinTests_SystemTests_LIBS
     codecov
-    GTest::main
+    GTest::gtest_main
     QwertycoinFramework::System
 )
 
@@ -356,7 +356,7 @@ set(QwertycoinTests_UnitTests_SOURCES
 
 set(QwertycoinTests_UnitTests_LIBS
     codecov
-    GTest::main
+    GTest::gtest_main
     QwertycoinFramework::CryptoNoteCore
     QwertycoinFramework::CryptoNoteProtocol
     QwertycoinFramework::Http


### PR DESCRIPTION
Tasks:
- [x] Updated Hunter to `v0.23.232`;
- [x] Fixed `GTest::gtest_main` dependency for tests.

**NOTE:** Original repo (`ruslo/hunter`) is in read-only mode since August 25th 2019, so I switched to `cpp-pm/hunter` which is an official alternative right now and is actively maintained (40+ new releases since August 25th 2019).

@nnian, this PR can be merged once you see that all CI builds are green.