### PR TITLE
docs: fix README wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ cmake --build . --config Release
 #### Visual Studio 2019
 
 - From the start menu, open "x64 Native Tools Command Prompt for vs2017";
-- And the run the following commands:
+- Then run the following commands:
 ```
 git clone https://github.com/qwertycoin-org/qwertycoin
 cd qwertycoin


### PR DESCRIPTION
## Goal

Verify the repository contribution flow with a harmless documentation-only change and an SSH-signed commit.

## Current behavior

The Windows build instructions contain the phrase "And the run the following commands".

## New behavior

The phrase is corrected to "Then run the following commands".

## Consensus impact

None. This changes README text only.

## Security impact

None.

## Tests

- `git diff --check origin/master...HEAD`
- Confirmed the commit contains an SSH signature header.

## Migration / compatibility

None.

## Known limitations

This PR intentionally exercises only documentation and commit-signature verification.
