### PR TITLE
chore: ignore macOS metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .DS_Store
+.AppleDouble
+.LSOverride
+._*
 /doc
 /build
 /tags


### PR DESCRIPTION
## Goal

Prevent macOS filesystem metadata from entering the Qwertycoin repository during archive imports or local development.

## Current behavior

`.DS_Store` is ignored, but related AppleDouble and Finder metadata patterns are not covered.

## New behavior

Ignore `.AppleDouble`, `.LSOverride`, and `._*` alongside `.DS_Store` at any tree depth.

## Consensus impact

None.

## Security impact

Reduces accidental publication of local filesystem metadata.

## Tests

- `git diff --check`
- `git check-ignore --no-index` for root and nested macOS metadata paths
- verified that no matching metadata files are tracked

## Migration / compatibility

No runtime or source compatibility impact.

## Known limitations

This prevents future additions; it does not rewrite repository history.

## Worked on by

- Alex (`nnian`)
