### PR TITLE
fix: fail closed for unavailable DNS checkpoints

### DIFF
--- a/docs/MAINNET_LAUNCH_READINESS.md
+++ b/docs/MAINNET_LAUNCH_READINESS.md
@@ -28,7 +28,7 @@ The closed QWCP public-address prototype is excluded from the launch baseline.
    `deploy/mainnet/build-rc-image.sh`.
 2. Run EPoSE unit, fuzz, ASan, and deployment-config validation.
 3. Push the RC image to each seed host or to the chosen registry.
-4. Start `seed-00`, `seed-01`, and `seed-02` with preserved service identity
+4. Start `seed-00`, `seed-01`, `seed-02`, and `seed-03` with preserved service identity
    volumes and fresh chain volumes for the coordinated launch chain.
 5. Confirm all seeds share genesis hash, top hash, height, network type, and
    EPoSE state hash.
@@ -49,6 +49,9 @@ The closed QWCP public-address prototype is excluded from the launch baseline.
   old `epose-pr*` images are not valid for public launch.
 - Repair or replace red GitHub Actions with recorded local validation.
 - Complete DNS-only bootstrap from an independent host.
+- Keep DNS checkpoints fail-closed until the trust model, tooling, independent
+  zones, authentication, and operational procedures in
+  `docs/epose/DNS_RECORDS.md` pass review.
 - Complete matured EPoSE reward spend and recipient receipt.
 - Record public mining from a non-seed miner.
 - Publish real release artifacts and hashes.

--- a/docs/epose/DNS_RECORDS.md
+++ b/docs/epose/DNS_RECORDS.md
@@ -1,7 +1,36 @@
 # Qwertycoin DNS Records
 
-This document records the DNS records expected by the current QWC v2 / EPoSE
-testnet branch and separates safe placeholders from release-gated metadata.
+This document records the DNS records expected by QWC v2 and separates safe
+operational records from release-gated metadata.
+
+## DNS Checkpoint Decision
+
+DNS checkpoints are **not available** in the current daemon. This is an
+intentional fail-closed release state:
+
+- the daemon does not query checkpoint records periodically;
+- `--disable-dns-checkpoints` remains accepted for operator compatibility;
+- `--enforce-dns-checkpointing` is rejected instead of silently enforcing an
+  empty checkpoint set;
+- local JSON checkpoints and hardcoded QWC checkpoints remain independent of
+  the DNS setting.
+
+Do not publish checkpoint TXT records yet. DNS checkpoint activation requires
+its own reviewed PR and all of these gates:
+
+1. QWC-owned checkpoint generation tooling with reproducible input/output;
+2. a documented signer and key-rotation/revocation procedure;
+3. multiple independently administered DNS zones and a defined quorum rule;
+4. authenticated DNS responses, including validated DNSSEC behavior and a
+   documented resolver/failure policy;
+5. monotonic height and conflict/reorg handling with positive and negative
+   tests;
+6. operator runbooks for publication, rollback, outage, compromise, and audit;
+7. live validation proving that unavailable or conflicting DNS cannot split
+   honest nodes or silently disable JSON/hardcoded checkpoints.
+
+DNS is bootstrap/hardening metadata, never an EPoSE oracle and never a
+replacement for RandomX chain selection.
 
 ## Update Metadata
 
@@ -83,6 +112,7 @@ hostnames:
 seed-00.qwertycoin.org
 seed-01.qwertycoin.org
 seed-02.qwertycoin.org
+seed-03.qwertycoin.org
 ```
 
 Each seed hostname should publish `A` and, where available, `AAAA` records for
@@ -97,6 +127,5 @@ Current P2P default:
 ```
 
 DNS checkpoints, DNS blocklists, and segregation-height records must remain
-disabled or unpublished until QWC-owned signing keys, generation tooling, and
-operational procedures are defined. These records must not be copied from
-Monero infrastructure.
+disabled or unpublished until the gates above are implemented and reviewed.
+These records must not be copied from Monero infrastructure.

--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -46,6 +46,11 @@ using namespace epee;
 
 namespace cryptonote
 {
+  bool dns_checkpoints_available()
+  {
+    return false;
+  }
+
   /**
    * @brief struct for loading a checkpoint from json
    */
@@ -240,7 +245,7 @@ namespace cryptonote
   bool checkpoints::load_checkpoints_from_dns(network_type nettype)
   {
     (void)nettype;
-    MINFO("Qwertycoin DNS checkpoints are disabled until QWC-owned signed checkpoint metadata is configured");
+    MDEBUG("Qwertycoin DNS checkpoints are unavailable until QWC-owned checkpoint metadata and trust policy are configured");
     return true;
   }
 

--- a/src/checkpoints/checkpoints.h
+++ b/src/checkpoints/checkpoints.h
@@ -44,6 +44,14 @@
 namespace cryptonote
 {
   /**
+   * @brief whether QWC-owned DNS checkpoint metadata is configured
+   *
+   * DNS checkpoints remain unavailable until the trust model, independent
+   * QWC-owned records, generation tooling, and release procedure are reviewed.
+   */
+  bool dns_checkpoints_available();
+
+  /**
    * @brief A container for blockchain checkpoints
    *
    * A checkpoint is a pre-defined hash for the block at a given height.
@@ -192,7 +200,7 @@ namespace cryptonote
      *
      * @param nettype network type
      *
-     * @return true if loading successful and no conflicts
+     * @return true if loading is disabled or succeeds without conflicts
      */
     bool load_checkpoints_from_dns(network_type nettype = MAINNET);
 

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -124,7 +124,7 @@ namespace cryptonote
   };
   const command_line::arg_descriptor<bool> arg_disable_dns_checkpoints = {
     "disable-dns-checkpoints"
-  , "Do not retrieve checkpoints from DNS"
+  , "Do not retrieve checkpoints from DNS (currently the default because QWC DNS checkpoints are unavailable)"
   };
   const command_line::arg_descriptor<size_t> arg_block_download_max_size  = {
     "block-download-max-size"
@@ -177,7 +177,7 @@ namespace cryptonote
   };
   static const command_line::arg_descriptor<bool> arg_dns_checkpoints  = {
     "enforce-dns-checkpointing"
-  , "checkpoints from DNS server will be enforced"
+  , "Enforce QWC DNS checkpoints (unavailable until QWC-owned checkpoint infrastructure is activated)"
   , false
   };
   static const command_line::arg_descriptor<uint64_t> arg_fast_block_sync = {
@@ -300,12 +300,14 @@ namespace cryptonote
   //-----------------------------------------------------------------------------------------------
   bool core::update_checkpoints(const bool skip_dns /* = false */)
   {
-    if (m_nettype != MAINNET || m_disable_dns_checkpoints) return true;
+    if (m_nettype != MAINNET) return true;
 
     if (m_checkpoints_updating.test_and_set()) return true;
 
     bool res = true;
-    if (!skip_dns && time(NULL) - m_last_dns_checkpoints_update >= 3600)
+    const bool dns_due = !skip_dns && !m_disable_dns_checkpoints && dns_checkpoints_available()
+      && time(NULL) - m_last_dns_checkpoints_update >= 3600;
+    if (dns_due)
     {
       res = m_blockchain_storage.update_checkpoints(m_checkpoints_path, true);
       m_last_dns_checkpoints_update = time(NULL);
@@ -419,10 +421,16 @@ namespace cryptonote
     }
 
 
-    set_enforce_dns_checkpoints(command_line::get_arg(vm, arg_dns_checkpoints));
+    const bool enforce_dns_checkpoints = command_line::get_arg(vm, arg_dns_checkpoints);
+    if (enforce_dns_checkpoints && !dns_checkpoints_available())
+    {
+      MERROR("--enforce-dns-checkpointing requested, but QWC DNS checkpoints are unavailable");
+      return false;
+    }
+    set_enforce_dns_checkpoints(enforce_dns_checkpoints);
     test_drop_download_height(command_line::get_arg(vm, arg_test_drop_download_height));
     m_offline = get_arg(vm, arg_offline);
-    m_disable_dns_checkpoints = get_arg(vm, arg_disable_dns_checkpoints);
+    m_disable_dns_checkpoints = get_arg(vm, arg_disable_dns_checkpoints) || !dns_checkpoints_available();
 
     if (!init_epose_service_node_config(vm))
       return false;

--- a/tests/unit_tests/checkpoints.cpp
+++ b/tests/unit_tests/checkpoints.cpp
@@ -34,6 +34,16 @@
 
 using namespace cryptonote;
 
+TEST(checkpoints_dns, remains_fail_closed_without_qwc_metadata)
+{
+  ASSERT_FALSE(dns_checkpoints_available());
+
+  checkpoints cp;
+  ASSERT_TRUE(cp.load_checkpoints_from_dns(MAINNET));
+  ASSERT_TRUE(cp.get_points().empty());
+  ASSERT_TRUE(cp.get_difficulty_points().empty());
+}
+
 
 TEST(checkpoints_is_alternative_block_allowed, handles_empty_checkpoints)
 {


### PR DESCRIPTION
## Goal

Make the current QWC DNS-checkpoint state explicit and fail closed while the
trust model and QWC-owned infrastructure remain undecided.

## Current behavior

- DNS checkpoint loading returns success without loading any checkpoints.
- `--enforce-dns-checkpointing` is accepted and therefore appears to enforce
  a checkpoint set even though that set is empty.
- the periodic checkpoint updater still enters the DNS branch once per hour;
- `--disable-dns-checkpoints` returns before local JSON checkpoint refreshes,
  coupling two independent checkpoint sources.

## New behavior

- exposes an explicit `dns_checkpoints_available()` capability, currently
  `false`;
- rejects `--enforce-dns-checkpointing` with a clear startup error;
- skips periodic DNS checkpoint work while the capability is unavailable;
- keeps local JSON checkpoint refreshes active when DNS is disabled;
- adds a unit test proving that the unavailable loader adds neither block nor
  difficulty checkpoints;
- documents the activation gates and the fourth seed host.

## Consensus impact

No block-validation, RandomX, chain-selection, EPoSE, reward, serialization, or
network-parameter rule changes. DNS checkpoint records were unavailable before
this PR and remain unavailable. Hardcoded QWC checkpoints and local JSON
checkpoints remain active and independent.

Future DNS-checkpoint activation requires a separate reviewed PR. The documented
gates include reproducible generation, signer/key procedures, independently
administered DNS zones, a quorum rule, authenticated DNS/DNSSEC behavior,
conflict/reorg tests, and compromise/outage runbooks.

## Security impact

Prevents an operator from believing an empty DNS checkpoint set is being
enforced. It also avoids turning an unresolved external metadata design into a
silent runtime dependency. DNS remains bootstrap/hardening metadata and cannot
become an EPoSE oracle or replace RandomX chain selection.

## Tests

- Release CMake configuration with tests enabled: passed
- `unit_tests` build: passed
- focused checkpoint tests: 4/4 passed
- complete EPoSE test case in the broader unit run: 76/76 passed
- `qwertycoind` build and version smoke: passed
- `--enforce-dns-checkpointing`: exits 1 with explicit unavailable error
- `--disable-dns-checkpoints`: daemon starts and shuts down cleanly on SIGTERM
- `git diff --check`: passed
- secret/private-key pattern scan: passed

The broader 1,316-test run exposed six pre-existing multisig vector failures
because the inherited fixtures still expect Monero testnet addresses. The run
was stopped later in the pre-existing `cryptonote_protocol_handler.race_condition`
test after it made no progress for several minutes. Neither area is touched by
this PR.

## Migration / compatibility

Default operation remains DNS-checkpoint-free. Existing deployments using
`--disable-dns-checkpoints` continue to work and now retain local JSON checkpoint
updates. Deployments explicitly using `--enforce-dns-checkpointing` must remove
that flag until QWC-owned checkpoint infrastructure is implemented.

## Known limitations

- DNS checkpoint generation and publication are not implemented.
- No signer, key rotation, independent-zone ownership, or quorum is selected.
- Current EPoSE documentation still contains stale historical `5/2/8`
  parameter descriptions in files marked as current; that drift needs a
  separate documentation PR.
- The inherited multisig address vectors need a separate QWC fixture update.

## Worked on by

- Alex (`nnian`)
