### PR TITLE
test(epose): enforce v2 release no-go gates

### DIFF
--- a/docs/epose/review/ADVERSARIAL_ACCEPTANCE_MATRIX.md
+++ b/docs/epose/review/ADVERSARIAL_ACCEPTANCE_MATRIX.md
@@ -1,0 +1,45 @@
+# EPoSE v2 Adversarial Acceptance Matrix
+
+**Date:** 2026-09-06
+**Release verdict:** **NO-GO**
+
+`Satisfied` below means the named property has direct executable evidence at the
+current layer. `Partial` means a non-activating primitive is covered but the
+canonical handler or multi-node result is still absent. `Not run` means no valid
+final-protocol execution can yet be performed. Partial rows remain release
+blockers.
+
+| Scenario | Status | Current evidence | Required final evidence |
+|---|---|---|---|
+| Post-seed subject/verifier grinding | Partial | CO-02 snapshot unit tests | HF18 block/reorg test on canonical state |
+| Registration changes after prior votes | Partial | CO-02 fixed-snapshot tests | Serialized records through connect/disconnect and replay |
+| Malicious threshold approves offline identity | Partial | CO-03 exact probability model | Parameter-bound network simulation and residual-risk statement |
+| Missing, forged, or replayed subject signature | Partial | CO-04 dual-signature negative tests | Live transport plus block-carrier rejection |
+| One backend serves many identities | Partial | CO-03 concentration model | Multi-identity proxy experiment; no independence claim |
+| Honest endpoint eclipsed or stale | Not run | Threat model only | Partition/stale-anchor network fixture without validation split |
+| Targeted verifier/payee outage | Partial | CO-03 availability model | Adaptive outage and settled-payout network test |
+| Inbound-only operators skip verification | Partial | CO-03 duty model | Measured verifier costs and final incentive analysis |
+| Registration flood near evidence expiry | Partial | CO-05 atomic budgets | Integrated deadline-aware template and sustained backlog test |
+| Fee-funded versus coinbase carrier | Partial | CO-05 byte-equivalence fixtures | Wallet-funded and miner-template blocks yielding equal state |
+| Reorg across enrollment/seed, A-B-A | Partial | CO-02/08 in-memory replay | LMDB, deep reorg, restart, and fresh-replay equality |
+| Receipt at deadline -1/0/+1 | Partial | CO-01/02 boundary tests | Serialized canonical-block vectors on independent hosts |
+| Reorg beyond retained undo | Partial | CO-08 returns rebuild-required | Full rebuild from canonical/pruned supported history |
+| Crash during connect or migration | Not run | Fail-atomic in-memory restore only | Process-kill injection around LMDB transactions |
+| Maximum valid block and malicious relay | Partial | CO-05/09 local counters | p95/p99 CPU/RAM/sync measurements under sustained load |
+| Unknown version/noncanonical crypto/malformed length | Partial | CO-04/05 parser/signature negatives | Fuzz/sanitizer matrix at integrated handler boundary |
+| Conflicting descriptors/duplicate receipts/retries | Partial | CO-02/04/07 deterministic tests | Canonical record processing from real blocks |
+| Miner omits or redirects service payout | Partial | CO-06 payment-proof unit tests | Coinbase construction/validation positive and negative blocks |
+| Empty qualified set | Not run | CO-06 alternatives fail closed | Owner-approved policy plus emission golden vectors |
+| Miner and service use same wallet | Partial | CO-06 allocation model | Matured spend and rescan on final wallet binary |
+| Proof transplanted to another coinbase/output | Partial | CO-06 substitution tests | Independent cryptographic review and block-level vectors |
+| Ten rewards to the same wallet | Partial | Unique one-time keys unit-tested | Ten matured, independently spent outputs with no collision |
+| Fresh sync, restart, and pruned/full convergence | Not run | CO-08 journal primitive | Final LMDB schema across four nodes and fresh replay |
+| Old history across activation | Partial | CO-01 version boundary model | Full pre/post-activation chain and deep-reorg validation |
+
+## Interpretation
+
+No row may be marked satisfied merely because a lower-level helper passed. A
+release row closes only when the final serialized protocol traverses the same
+parsing, state, storage, reward, wallet, and reorg paths used by a production
+node. The machine-readable top-level status remains in
+`RELEASE_GATES_V2.json`.

--- a/docs/epose/review/FINDINGS.md
+++ b/docs/epose/review/FINDINGS.md
@@ -69,3 +69,10 @@ These properties are necessary but do not close the P0 findings above.
 No later package may silently relax an earlier invariant to make a test pass.
 Consensus, cryptography, wallet, storage, and operational changes should remain
 separate reviewable commits and, where practical, separate pull requests.
+
+CO-10/11 assessment is recorded in `RELEASE_READINESS.md`,
+`ADVERSARIAL_ACCEPTANCE_MATRIX.md`, and the machine-readable
+`RELEASE_GATES_V2.json`. The current result is a deliberate no-go: component
+evidence from CO-02 through CO-09 does not close a finding until the final HF18
+handler, persistent state, network path, reward/wallet path, and release build
+traverse it end to end.

--- a/docs/epose/review/README.md
+++ b/docs/epose/review/README.md
@@ -21,6 +21,12 @@ authorize a node to reinterpret an already accepted block.
   fail-closed activation rules.
 - [`VALIDATION.md`](VALIDATION.md) records the baseline build and test commands,
   results, and explicit gaps.
+- [`RELEASE_READINESS.md`](RELEASE_READINESS.md) records the CO-10/11 no-go
+  assessment and the preconditions for a valid four-node funds-safety run.
+- [`RELEASE_GATES_V2.json`](RELEASE_GATES_V2.json) is the machine-readable,
+  fail-closed release evidence ledger.
+- [`ADVERSARIAL_ACCEPTANCE_MATRIX.md`](ADVERSARIAL_ACCEPTANCE_MATRIX.md) maps
+  the required attacks and failure modes to current and final evidence.
 
 ## Governing rule
 

--- a/docs/epose/review/RELEASE_GATES_V2.json
+++ b/docs/epose/review/RELEASE_GATES_V2.json
@@ -1,0 +1,116 @@
+{
+  "gates": [
+    {
+      "evidence": [
+        "docs/epose/review/SOURCE_BASELINE.md",
+        "docs/epose/review/FINDINGS.md"
+      ],
+      "id": "source_and_invariant_baseline",
+      "state": "satisfied",
+      "summary": "Public source, inherited baseline, deployed observations, and F01-F21 ownership are recorded."
+    },
+    {
+      "evidence": [
+        "docs/epose/PROTOCOL.md",
+        "docs/epose/CONSENSUS_INVARIANTS.md",
+        "tests/epose/vectors/co01_transition_v2.json"
+      ],
+      "id": "normative_transition_specification",
+      "state": "satisfied",
+      "summary": "HF18 reservation, epoch ordering, canonical envelope framing, and boundary vectors are specified."
+    },
+    {
+      "evidence": [
+        "src/epose/membership_v2.cpp",
+        "src/epose/envelope_v2.cpp",
+        "src/epose/reward_v2.cpp"
+      ],
+      "id": "consensus_handler_integration",
+      "state": "blocked",
+      "summary": "V2 primitives are deliberately unreachable from HF17 and are not integrated with block parsing, connect/disconnect, templates, or coinbase validation."
+    },
+    {
+      "evidence": [
+        "docs/epose/SECURITY_PARAMETERS.md",
+        "docs/epose/review/results/security_parameters_v1.json"
+      ],
+      "id": "approved_security_parameters",
+      "state": "blocked",
+      "summary": "No owner-approved risk budget or optimized multi-hardware admission/committee parameter set exists."
+    },
+    {
+      "evidence": [
+        "docs/epose/review/ADR-0003-REWARD-SEMANTICS.md"
+      ],
+      "id": "reward_and_emission_decision",
+      "state": "blocked",
+      "summary": "Empty-set policy and emission accounting require an explicit tokenomics decision."
+    },
+    {
+      "evidence": [
+        "docs/epose/review/ADR-0003-REWARD-SEMANTICS.md"
+      ],
+      "id": "independent_payment_proof_review",
+      "state": "not_run",
+      "summary": "The scoped payment-proof candidate has not received independent cryptographic review."
+    },
+    {
+      "evidence": [
+        "docs/epose/review/ADR-0005-PERSISTENT-STATE.md"
+      ],
+      "id": "atomic_lmdb_and_pruning",
+      "state": "blocked",
+      "summary": "The journal primitive is not connected to same-transaction LMDB state, crash recovery, migration, or pruned validation."
+    },
+    {
+      "evidence": [
+        "docs/epose/review/ADR-0006-RESOURCE-POLICY.md"
+      ],
+      "id": "network_and_rpc_resource_integration",
+      "state": "blocked",
+      "summary": "Probe, P2P, RPC, admission-cache, and DNS-race protections are not connected to live handlers or sustained-load tests."
+    },
+    {
+      "evidence": [
+        "tests/epose/integration/local_epose_network.sh"
+      ],
+      "id": "four_node_consensus_convergence",
+      "state": "not_run",
+      "summary": "No final-protocol four-node enrollment, receipt, payout, partition, restart, and deep-reorg run exists."
+    },
+    {
+      "evidence": [
+        "docs/epose/review/VALIDATION.md"
+      ],
+      "id": "wallet_funds_safety_e2e",
+      "state": "not_run",
+      "summary": "Maturity, spend, recipient receipt, rescan, repeated output uniqueness, and reward-fork replacement are not proven on final binaries."
+    },
+    {
+      "evidence": [
+        "docs/epose/review/SOURCE_BASELINE.md"
+      ],
+      "id": "reproducible_release_matrix",
+      "state": "not_run",
+      "summary": "Linux, Docker, macOS Apple Silicon, checksums, source-to-binary identity, and dependency manifest are incomplete."
+    },
+    {
+      "evidence": [
+        "docs/epose/review/ADR-0001-ACTIVATION-STATUS.md"
+      ],
+      "id": "independent_consensus_review",
+      "state": "not_run",
+      "summary": "No independent adversarial review of the integrated hardened protocol exists."
+    },
+    {
+      "evidence": [
+        "docs/epose/PARAMETER_MANIFEST_V2.json"
+      ],
+      "id": "signed_activation_manifest",
+      "state": "blocked",
+      "summary": "Genesis, activation height/hash, final limits, parameters, state schema, and release binaries remain unset."
+    }
+  ],
+  "overall_status": "no-go",
+  "schema_version": 1
+}

--- a/docs/epose/review/RELEASE_READINESS.md
+++ b/docs/epose/review/RELEASE_READINESS.md
@@ -1,0 +1,102 @@
+# EPoSE v2 Release Readiness
+
+**Assessment date:** 2026-09-06
+
+**Status:** **NO-GO for economic activation**
+
+**Scope:** CO-10 and CO-11 gate assessment
+
+## Decision
+
+The stacked CO-00 through CO-09 branches provide reviewed design boundaries and
+non-activating C++ primitives. They do not yet form an integrated HF18 protocol.
+The current mainnet manifest intentionally contains unset consensus parameters
+and has status `not-activatable`.
+
+It would therefore be invalid to reset a network from genesis and describe the
+result as an EPoSE v2 funds-safety test. The existing Docker integration harness
+exercises the historical HF17 protocol, including the legacy reward view-key
+interface. It cannot establish the HF18 properties required by CO-10.
+
+No production, public-testnet, or four-host deployment of this branch is
+authorized by this assessment.
+
+## Machine-readable gate
+
+`RELEASE_GATES_V2.json` is the evidence ledger. The standard-library evaluator
+fails closed when a required manifest value is absent, a gate is unresolved, a
+gate identifier is duplicated, or the declared overall state disagrees with
+the computed state.
+
+```bash
+python3 tests/epose/release_gate_v2.py \
+  --manifest docs/epose/PARAMETER_MANIFEST_V2.json \
+  --gates docs/epose/review/RELEASE_GATES_V2.json
+```
+
+The command exits nonzero while activation is blocked. Review and test jobs that
+intend to prove the present no-go state must use `--expect no-go`; they must not
+ignore the default failure.
+
+## Current result
+
+- 2 of 13 top-level release gates are satisfied.
+- 24 required manifest values remain unset.
+- 11 gates remain blocked or not run.
+- The security-parameter study independently reports
+  `no_go_for_economic_activation`.
+
+The two satisfied gates are the source/invariant baseline and normative
+transition reservation. All implementation evidence through CO-09 remains
+valuable, but a component unit test is not promoted to a release-gate pass until
+the component is connected to the canonical block transition and tested there.
+
+## Blocking implementation work
+
+1. Integrate the version-aware envelope and record codecs into HF18 parsing,
+   block connect/disconnect, relay, miner templates, and fee-funded wallet
+   construction without changing HF17 history.
+2. Store lifecycle, snapshot, receipt, qualification, reward, and emission state
+   atomically with the canonical LMDB block transaction; prove migration,
+   pruning, rebuild, crash recovery, and deep rollback.
+3. Connect the bounded probe/descriptor policy to live P2P and RPC handlers and
+   measure worst-valid-block plus sustained invalid-load behavior.
+4. Select committee, round, admission, capacity, and resource constants from
+   optimized measurements on the supported hardware classes and an approved
+   adversarial risk budget.
+5. Approve one empty-set and emission policy. The implementation must then prove
+   exact inherited emission continuity and the PoW-security consequence.
+6. Obtain independent review of the scoped payment proof and the integrated
+   consensus state transition.
+
+## CO-10 execution preconditions
+
+The four-host test may start only when all six items above are closed and the
+candidate manifest is complete except for a future activation height/hash that
+is deliberately assigned at release freeze. Before any reset:
+
+- inventory every container, volume, wallet, chain directory, and persistent
+  service identity on the target host;
+- preserve wallets, seeds, and service identity keys separately from disposable
+  chain state;
+- pin one source commit, submodule set, compiler/toolchain, image digest, and
+  parameter-manifest hash;
+- use newly generated worthless test wallets;
+- never perform host administration on shared seed-02 or seed-03; QWC actions on
+  those machines remain confined to Docker;
+- treat an unconfirmed SSH host-key replacement as unavailable infrastructure.
+
+The eventual run must cover enrollment, authenticated service, both carriers,
+qualification, payout, maturity, spend, recipient receipt, rescans, restarts,
+partition/heal, payout-fork replacement, deep reorg, fresh replay, and identical
+state roots on all honest nodes.
+
+## CO-11 release conditions
+
+Activation requires a complete signed manifest, reproducible source-to-binary
+evidence, Linux/Docker/macOS build results, checksums, operator migration and
+rollback guidance, dependency inventory, public protocol/vectors, and linked
+independent review findings. No administrator RPC, DNS record, privileged key,
+or local relay decision may change consensus qualification or payout rules.
+
+Until those conditions are met, the only correct release result is **NO-GO**.

--- a/docs/epose/review/VALIDATION.md
+++ b/docs/epose/review/VALIDATION.md
@@ -378,3 +378,35 @@ Results reproduced on 2026-09-06:
 This is not handler or load-test evidence. P2P/RPC/probe integration,
 streaming/no-redirect socket enforcement, DNS race fixtures, RandomX VM hooks,
 fuzzing, and sustained malicious-load benchmarks remain open.
+
+## CO-10/11 release-gate validation
+
+Commands:
+
+```text
+python3 -m py_compile tests/epose/release_gate_v2.py tests/epose/test_release_gate_v2.py
+python3 tests/epose/test_release_gate_v2.py
+python3 tests/epose/release_gate_v2.py \
+  --manifest docs/epose/PARAMETER_MANIFEST_V2.json \
+  --gates docs/epose/review/RELEASE_GATES_V2.json \
+  --expect no-go
+```
+
+Results reproduced on 2026-09-06:
+
+- release-gate evaluator tests: **6/6 passed**;
+- all EPoSE Python model/gate tests: **27/27 passed**;
+- complete focused C++ EPoSE binary: **143/143 passed**;
+- EPoSE fuzz corpus: **11/11 files passed**;
+- daemon rebuilt and linked at stacked base `e90f64c60`;
+- malformed schema, duplicate gate, unsupported state, evidence-free satisfied
+  gate, and false ready declaration fail closed;
+- the current result is `no-go`: 2/13 top-level gates satisfied, 11 unresolved,
+  and 24 required manifest fields unset;
+- the reservation-manifest SHA-256 remains
+  `3cc33c916af6cd377485e163dd41006a9ea6ff8899ae4e31205cd01f104fe5f1`.
+
+No genesis reset or four-host execution was performed. The existing integration
+harness exercises HF17 and cannot establish HF18 funds safety while the v2
+handler, LMDB, final parameters, reward policy, and payment-proof review remain
+open. Running it and relabeling the result would be false activation evidence.

--- a/tests/epose/release_gate_v2.py
+++ b/tests/epose/release_gate_v2.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Fail-closed EPoSE v2 release-gate evaluator.
+
+This tool does not authorize activation.  It checks that the machine-readable
+manifest and evidence ledger agree, and reports every missing activation field
+and unresolved gate.  A ready result is possible only when both inputs are
+explicitly complete.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ALLOWED_GATE_STATES = frozenset({"satisfied", "blocked", "not_run"})
+
+REQUIRED_MANIFEST_PATHS = (
+    "activation.block_hash",
+    "activation.height",
+    "network.genesis_hash",
+    "admission.lease_epochs",
+    "admission.leading_zero_bits",
+    "committee.round_offsets",
+    "committee.rounds_required",
+    "committee.size",
+    "committee.threshold",
+    "resource_limits.max_active_population",
+    "resource_limits.max_admission_verifications_per_block",
+    "resource_limits.max_envelope_bytes_per_transaction",
+    "resource_limits.max_envelopes_per_transaction",
+    "resource_limits.max_epose_bytes_per_block",
+    "resource_limits.max_records_per_block",
+    "resource_limits.max_records_per_envelope",
+    "resource_limits.max_signature_verifications_per_block",
+    "resource_limits.minimum_undo_blocks",
+    "reward.empty_set_policy",
+    "reward.emission_accounting",
+    "reward.fee_policy",
+    "reward.payment_proof_scheme",
+    "state.index_schema",
+    "state.pruned_validation_mode",
+)
+
+
+class GateError(ValueError):
+    pass
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return (json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False) + "\n").encode()
+
+
+def digest(value: Any) -> str:
+    return hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def get_path(value: dict[str, Any], path: str) -> Any:
+    current: Any = value
+    for component in path.split("."):
+        if not isinstance(current, dict) or component not in current:
+            raise GateError(f"missing manifest path: {path}")
+        current = current[component]
+    return current
+
+
+def evaluate(manifest: dict[str, Any], ledger: dict[str, Any]) -> dict[str, Any]:
+    if ledger.get("schema_version") != 1:
+        raise GateError("unsupported release-gate ledger schema")
+    gates = ledger.get("gates")
+    if not isinstance(gates, list) or not gates:
+        raise GateError("release-gate ledger must contain gates")
+
+    gate_ids: set[str] = set()
+    unresolved: list[dict[str, str]] = []
+    for gate in gates:
+        if not isinstance(gate, dict):
+            raise GateError("gate must be an object")
+        gate_id = gate.get("id")
+        state = gate.get("state")
+        summary = gate.get("summary")
+        evidence = gate.get("evidence")
+        if not isinstance(gate_id, str) or not gate_id:
+            raise GateError("gate id must be a nonempty string")
+        if gate_id in gate_ids:
+            raise GateError(f"duplicate gate id: {gate_id}")
+        gate_ids.add(gate_id)
+        if state not in ALLOWED_GATE_STATES:
+            raise GateError(f"invalid state for {gate_id}: {state!r}")
+        if not isinstance(summary, str) or not summary:
+            raise GateError(f"gate {gate_id} requires a summary")
+        if not isinstance(evidence, list) or not all(isinstance(item, str) and item for item in evidence):
+            raise GateError(f"gate {gate_id} evidence must be a string list")
+        if state == "satisfied" and not evidence:
+            raise GateError(f"satisfied gate {gate_id} requires evidence")
+        if state != "satisfied":
+            unresolved.append({"id": gate_id, "state": state, "summary": summary})
+
+    missing_fields = [path for path in REQUIRED_MANIFEST_PATHS if get_path(manifest, path) is None]
+    manifest_ready = manifest.get("status") == "activatable"
+    declared = ledger.get("overall_status")
+    computed = "ready" if manifest_ready and not missing_fields and not unresolved else "no-go"
+    if declared != computed:
+        raise GateError(f"declared overall_status {declared!r} disagrees with computed {computed!r}")
+
+    return {
+        "schema_version": 1,
+        "overall_status": computed,
+        "manifest_sha256": digest(manifest),
+        "gate_ledger_sha256": digest(ledger),
+        "manifest_status": manifest.get("status"),
+        "missing_manifest_fields": missing_fields,
+        "unresolved_gates": unresolved,
+        "satisfied_gate_count": len(gates) - len(unresolved),
+        "total_gate_count": len(gates),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--gates", type=Path, required=True)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--expect", choices=("ready", "no-go"))
+    args = parser.parse_args()
+
+    try:
+        manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
+        ledger = json.loads(args.gates.read_text(encoding="utf-8"))
+        result = evaluate(manifest, ledger)
+    except (OSError, json.JSONDecodeError, GateError) as exc:
+        print(f"release-gate evaluation failed: {exc}", file=sys.stderr)
+        return 2
+
+    rendered = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+
+    if args.expect is not None:
+        if result["overall_status"] != args.expect:
+            print(
+                f"expected {args.expect!r}, got {result['overall_status']!r}",
+                file=sys.stderr,
+            )
+            return 1
+        return 0
+    return 0 if result["overall_status"] == "ready" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/epose/test_release_gate_v2.py
+++ b/tests/epose/test_release_gate_v2.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+import copy
+import importlib.util
+import json
+import sys
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("release_gate_v2.py")
+SPEC = importlib.util.spec_from_file_location("epose_release_gate_v2", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+ROOT = Path(__file__).parents[2]
+
+
+class ReleaseGateTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.manifest = json.loads((ROOT / "docs/epose/PARAMETER_MANIFEST_V2.json").read_text())
+        cls.ledger = json.loads((ROOT / "docs/epose/review/RELEASE_GATES_V2.json").read_text())
+
+    def test_current_ledger_proves_no_go(self):
+        result = MODULE.evaluate(self.manifest, self.ledger)
+        self.assertEqual("no-go", result["overall_status"])
+        self.assertEqual("not-activatable", result["manifest_status"])
+        self.assertIn("activation.height", result["missing_manifest_fields"])
+        self.assertGreater(len(result["unresolved_gates"]), 0)
+
+    def test_declared_ready_cannot_hide_null_manifest_fields(self):
+        ledger = copy.deepcopy(self.ledger)
+        ledger["overall_status"] = "ready"
+        with self.assertRaisesRegex(MODULE.GateError, "disagrees"):
+            MODULE.evaluate(self.manifest, ledger)
+
+    def test_duplicate_gate_id_fails(self):
+        ledger = copy.deepcopy(self.ledger)
+        ledger["gates"].append(copy.deepcopy(ledger["gates"][0]))
+        with self.assertRaisesRegex(MODULE.GateError, "duplicate gate"):
+            MODULE.evaluate(self.manifest, ledger)
+
+    def test_satisfied_gate_requires_evidence(self):
+        ledger = copy.deepcopy(self.ledger)
+        ledger["gates"][0]["evidence"] = []
+        with self.assertRaisesRegex(MODULE.GateError, "requires evidence"):
+            MODULE.evaluate(self.manifest, ledger)
+
+    def test_unknown_gate_state_fails(self):
+        ledger = copy.deepcopy(self.ledger)
+        ledger["gates"][0]["state"] = "waived"
+        with self.assertRaisesRegex(MODULE.GateError, "invalid state"):
+            MODULE.evaluate(self.manifest, ledger)
+
+    def test_fully_populated_fixture_can_be_ready(self):
+        manifest = copy.deepcopy(self.manifest)
+        for path in MODULE.REQUIRED_MANIFEST_PATHS:
+            current = manifest
+            parts = path.split(".")
+            for part in parts[:-1]:
+                current = current[part]
+            if current[parts[-1]] is None:
+                current[parts[-1]] = 1
+        manifest["status"] = "activatable"
+        ledger = copy.deepcopy(self.ledger)
+        for gate in ledger["gates"]:
+            gate["state"] = "satisfied"
+            gate["evidence"] = ["fixture-evidence"]
+        ledger["overall_status"] = "ready"
+        result = MODULE.evaluate(manifest, ledger)
+        self.assertEqual("ready", result["overall_status"])
+        self.assertEqual([], result["missing_manifest_fields"])
+        self.assertEqual([], result["unresolved_gates"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Goal
Turn CO-10/11 into a fail-closed release decision instead of overstating component tests as activation evidence.

## Current behavior
The stacked CO-02 through CO-09 branches provide non-activating primitives, while the reservation manifest still has 24 unset required fields. No single machine-readable gate prevents those partial results from being presented as release readiness.

## New behavior
- add a deterministic release-gate evaluator and negative tests;
- add a machine-readable 13-gate evidence ledger;
- record the explicit economic-activation NO-GO;
- map the adversarial acceptance matrix to current and required final evidence;
- define the preconditions for a valid four-node/funds-safety run and release review.

The evaluator exits nonzero by default for the present state. Review jobs may use `--expect no-go` to prove that the gate remains closed.

## Consensus impact
None. This PR does not activate HF18, parse v2 records in canonical blocks, change rewards, alter storage, reset genesis, or reinterpret HF17 history.

## Security impact
Positive fail-closed control: missing manifest fields, duplicate gates, unsupported states, evidence-free satisfied gates, and a false ready declaration are rejected. The ledger reports 2/13 gates satisfied, 11 unresolved, and 24 required manifest values unset.

## Tests
- 6/6 release-gate evaluator tests
- 27/27 EPoSE Python model/gate tests
- 143/143 focused C++ EPoSE tests
- 11/11 EPoSE fuzz corpus files
- daemon target rebuilt at stacked base `e90f64c60`
- Pandoc, JSON, evidence-path, secret-pattern, and `git diff --check` validation

## Migration / compatibility
None. This is a non-activating gate/reporting layer stacked on PR #175.

## Known limitations
The gate correctly remains NO-GO. Canonical HF18 handler integration, same-transaction LMDB storage, final parameters, reward/emission decision, live network/resource integration, four-node wallet E2E, reproducible release matrix, and independent cryptographic/consensus review remain unresolved.

No genesis reset or four-host run was performed because the current Docker harness exercises HF17 and cannot prove HF18 funds safety.

## Worked on by
- Alex (`nnian`)
